### PR TITLE
Bugfix/nat

### DIFF
--- a/R/http_request_error.R
+++ b/R/http_request_error.R
@@ -47,14 +47,44 @@ http_request_error <- function(
         jsonlite::fromJSON() |>
         magrittr::extract2("errors")
       if (!is.null(api_error)) {
+        error_message <- api_error |>
+          dplyr::pull("message")
+        error_detail <- api_error |>
+          dplyr::pull("detail")
+        toggle_message(api_error |> dplyr::pull("message"), verbose = verbose)
         status_response_text <- paste0(
-          api_error |>
-            dplyr::pull("message"),
+          error_message,
           "\n     ",
-          api_error |>
-            dplyr::pull("detail") |>
-            unlist() |>
-            paste0(collapse = ", ")
+          ifelse(
+            "items" %in% names(error_detail),
+            error_detail |>
+              dplyr::pull("items") |>
+              unlist() |>
+              paste0(collapse = ", "),
+            ""
+          ),
+          ifelse(
+            "value" %in% names(error_detail),
+            paste0(
+              "\n     Provided values: ",
+              error_detail |>
+                dplyr::pull("value") |>
+                unlist() |>
+                paste0(collapse = ", ")
+            ),
+            ""
+          ),
+          ifelse(
+            "allowed" %in% names(error_detail),
+            paste0(
+              "\n     Allowed values: ",
+              error_detail |>
+                dplyr::pull("allowed") |>
+                unlist() |>
+                paste0(collapse = ", ")
+            ),
+            ""
+          )
         )
       }
     }

--- a/R/http_request_error.R
+++ b/R/http_request_error.R
@@ -48,19 +48,20 @@ http_request_error <- function(
         magrittr::extract2("errors")
       if (!is.null(api_error)) {
         error_message <- api_error |>
-          dplyr::pull("message")
+          dplyr::pull("message") |>
+          unique()
         error_detail <- api_error |>
           dplyr::pull("detail")
         toggle_message(api_error |> dplyr::pull("message"), verbose = verbose)
         status_response_text <- paste0(
           error_message,
-          "\n     ",
           ifelse(
             "items" %in% names(error_detail),
-            error_detail |>
+            paste0("\n     Error items: ",error_detail |>
               dplyr::pull("items") |>
               unlist() |>
-              paste0(collapse = ", "),
+              paste0(collapse = ", ")
+              ),
             ""
           ),
           ifelse(

--- a/R/post_dataset.R
+++ b/R/post_dataset.R
@@ -104,7 +104,7 @@ post_dataset <- function(
         jsonlite::fromJSON()
     )
   }
-  http_request_error(response)
+  http_request_error(response, verbose = verbose)
   # Unless the user specifies a specific page of results to get, loop through all available pages.
   response_json <- response |>
     httr::content("text") |>

--- a/R/query_dataset_utils.R
+++ b/R/query_dataset_utils.R
@@ -79,7 +79,7 @@ todf_geographies <- function(geographies) {
       )
     }
     if ("locations" %in% names(geographies)) {
-      locations <- geographies|>
+      locations <- geographies |>
         magrittr::extract2("locations") |>
         stringr::str_split("\\|", simplify = TRUE) |>
         as.data.frame() |>

--- a/tests/testthat/test-query_dataset.R
+++ b/tests/testthat/test-query_dataset.R
@@ -100,6 +100,17 @@ test_that("Geography query returns expected geographies", {
   )
 })
 
+test_that("Non-standard geographic level", {
+  expect_error(
+    query_dataset(example_id(), geographies = "Nat", indicators = example_id("indicator")),
+    paste0(
+      "\nHTTP connection error: 400\nMust be one of the allowed values.",
+      "\n     Provided values: Nat\n     Allowed values: ",
+      "EDA, INST, LA, LAD, LEP, LSIP, MAT, MCA, NAT, OA, PA, PCON, PROV, REG, RSC, SCH, SPON, WARD"
+    )
+  )
+})
+
 test_that("Test filter-combinations POST dataset query", {
   query_result <- query_dataset(
     example_id(group = "attendance"),
@@ -146,7 +157,7 @@ test_that("Test filter-combinations POST dataset query", {
 test_that("Indicators not found in data set", {
   expect_error(
     query_dataset(example_id(), indicators = c("uywet", "uywed")),
-    "\nHTTP connection error: 400\nOne or more indicators could not be found.\n     uywet, uywed"
+    "\nHTTP connection error: 400\nOne or more indicators could not be found.\n     Error items: uywet, uywed"
   )
 })
 


### PR DESCRIPTION
# Brief overview of changes

When a non-standard geographic level was provided to a query, the error message was concatenating the given level with the allowed levels, making the error message confusing. This update splits them out clearly in the error message.

## Why are these changes being made?

Clarity for users

## Detailed description of changes

Just expanding out the error message provided by the API using some extra code in `http_request_error()`. Then added a new test to keep tabs on it.

## Additional information for reviewers

...

## Issue ticket number/s and link

#65 