### PR TITLE
New feature/preview token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ rsconnect/
 .Rproj.user
 docs
 inst/doc
+dev_notes.md

--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,3 @@ rsconnect/
 .Rproj.user
 docs
 inst/doc
-dev_notes.md

--- a/R/api_url.R
+++ b/R/api_url.R
@@ -52,21 +52,22 @@
 #'   indicators = example_id("indicator")
 #' )
 api_url <- function(
-    endpoint = "get-publications",
-    search = NULL,
-    publication_id = NULL,
-    dataset_id = NULL,
-    indicators = NULL,
-    time_periods = NULL,
-    geographic_levels = NULL,
-    locations = NULL,
-    filter_items = NULL,
-    dataset_version = NULL,
-    ees_environment = NULL,
-    api_version = NULL,
-    page_size = NULL,
-    page = NULL,
-    verbose = FALSE) {
+  endpoint = "get-publications",
+  search = NULL,
+  publication_id = NULL,
+  dataset_id = NULL,
+  indicators = NULL,
+  time_periods = NULL,
+  geographic_levels = NULL,
+  locations = NULL,
+  filter_items = NULL,
+  dataset_version = NULL,
+  ees_environment = NULL,
+  api_version = NULL,
+  page_size = NULL,
+  page = NULL,
+  verbose = FALSE
+) {
   # Creating a master switch here for ees_environment, so that when we switch from dev to test and
   # then subsequently from test to prod, we can just change it here and everything should follow
   # from here. ees_environment should default to NULL for most other functions. Probably not a
@@ -90,14 +91,21 @@ api_url <- function(
   validate_endpoint(endpoint)
 
   is_valid_dataset_info <- function(dataset_id, dataset_version) {
-    !is.null(dataset_id) & (is.numeric(dataset_version) | is.null(dataset_version))
+    !is.null(dataset_id) &
+      (is.numeric(dataset_version) | is.null(dataset_version))
   }
 
   # Check that if endpoint requires a data set then dataset_id is not null
-  if (endpoint %in% c(
-    "get-summary", "get-dataset-versions", "get-meta",
-    "get-csv", "get-data", "post-data"
-  )
+  if (
+    endpoint %in%
+      c(
+        "get-summary",
+        "get-dataset-versions",
+        "get-meta",
+        "get-csv",
+        "get-data",
+        "post-data"
+      )
   ) {
     validate_ees_id(dataset_id, level = "dataset")
     if (is_valid_dataset_info(dataset_id, dataset_version) == FALSE) {
@@ -125,7 +133,9 @@ api_url <- function(
 
   endpoint_base_version <- paste0(
     endpoint_base[[ees_environment]],
-    "v", api_version, "/"
+    "v",
+    api_version,
+    "/"
   )
 
   if (endpoint == "get-publications") {
@@ -152,7 +162,14 @@ api_url <- function(
       endpoint_base_version,
       "data-sets/",
       ifelse(
-        endpoint %in% c("get-summary", "get-dataset-versions", "get-meta", "get-data", "post-data"),
+        endpoint %in%
+          c(
+            "get-summary",
+            "get-dataset-versions",
+            "get-meta",
+            "get-data",
+            "post-data"
+          ),
         dataset_id,
         ""
       )
@@ -214,11 +231,26 @@ api_url <- function(
       )
     }
   }
-  if (endpoint %in% c(
-    "get-publications", "get-data-catalogue", "get-summary", "get-meta", "get-csv"
-  )) {
+  if (
+    endpoint %in%
+      c(
+        "get-publications",
+        "get-data-catalogue",
+        "get-summary",
+        "get-meta",
+        "get-csv"
+      )
+  ) {
     if (
-      any(!is.null(c(time_periods, geographic_levels, locations, filter_items, indicators)))
+      any(
+        !is.null(c(
+          time_periods,
+          geographic_levels,
+          locations,
+          filter_items,
+          indicators
+        ))
+      )
     ) {
       warning(
         paste0(

--- a/R/get_dataset.R
+++ b/R/get_dataset.R
@@ -24,19 +24,21 @@
 #'   indicators = example_id("indicator")
 #' )
 get_dataset <- function(
-    dataset_id,
-    indicators,
-    time_periods = NULL,
-    geographic_levels = NULL,
-    locations = NULL,
-    filter_items = NULL,
-    dataset_version = NULL,
-    ees_environment = NULL,
-    api_version = NULL,
-    page = NULL,
-    page_size = 10000,
-    parse = TRUE,
-    verbose = FALSE) {
+  dataset_id,
+  indicators,
+  time_periods = NULL,
+  geographic_levels = NULL,
+  locations = NULL,
+  filter_items = NULL,
+  dataset_version = NULL,
+  preview_token = NULL,
+  ees_environment = NULL,
+  api_version = NULL,
+  page = NULL,
+  page_size = 10000,
+  parse = TRUE,
+  verbose = FALSE
+) {
   api_call <- api_url(
     "get-data",
     dataset_id = dataset_id,
@@ -53,14 +55,17 @@ get_dataset <- function(
     verbose = verbose
   )
   response <- api_call |>
-    httr::GET()
+    httr::GET(httr::add_headers(`Preview-Token` = preview_token))
   http_request_error(response)
   # Unless the user specifies a specific page of results to get, loop through all available pages.
   response_json <- response |>
     httr::content("text") |>
     jsonlite::fromJSON()
   if (verbose) {
-    message(paste("Total number of pages retrieved: ", response_json$paging$totalPages))
+    message(paste(
+      "Total number of pages retrieved: ",
+      response_json$paging$totalPages
+    ))
   }
   dfresults <- response_json |>
     magrittr::extract2("results")
@@ -70,7 +75,9 @@ get_dataset <- function(
     if (response_json$paging$totalPages > 1) {
       toggle_message(
         paste(
-          "Downloading up to", response_json$paging$totalPages * page_size, "rows.",
+          "Downloading up to",
+          response_json$paging$totalPages * page_size,
+          "rows.",
           "This may take a while.",
           "We recommend downloading the full data set using preview_dataset()",
           "for large volumes of data"
@@ -93,12 +100,17 @@ get_dataset <- function(
           page = page,
           verbose = verbose
         ) |>
-          httr::GET() |>
+          httr::GET(httr::add_headers(`Preview-Token` = preview_token)) |>
           httr::content("text") |>
           jsonlite::fromJSON()
         response_page |> warning_max_pages()
         toggle_message(
-          paste0("Retrieved page ", page, " of ", response_json$paging$totalPages),
+          paste0(
+            "Retrieved page ",
+            page,
+            " of ",
+            response_json$paging$totalPages
+          ),
           verbose = verbose
         )
         dfresults <- dfresults |>
@@ -113,8 +125,10 @@ get_dataset <- function(
     dfresults <- dfresults |>
       parse_api_dataset(
         dataset_id,
-        verbose = verbose,
-        ees_environment = ees_environment
+        dataset_version,
+        preview_token = preview_token,
+        ees_environment = ees_environment,
+        verbose = verbose
       )
   }
   return(dfresults)

--- a/R/get_dataset.R
+++ b/R/get_dataset.R
@@ -10,7 +10,7 @@
 #' any of those items.
 #'
 #' @inheritParams api_url
-#' @param parse Logical flag to activate parsing of the results. Default: TRUE
+#' @inheritParams query_dataset
 #'
 #' @return Data frame containing query results of an API data set
 #'

--- a/R/get_dataset_versions.R
+++ b/R/get_dataset_versions.R
@@ -1,7 +1,6 @@
 #' Get data set versions
 #'
 #' @inheritParams api_url
-#' @param preview_token
 #' @param detail Level of detail to return. Given as a character string, it should be one of:
 #' "light" (default) or "full".
 #' Using "light" gives the following:
@@ -34,7 +33,6 @@
 #' get_dataset_versions(dataset_id = example_id(group = "attendance"))
 get_dataset_versions <- function(
   dataset_id,
-  preview_token = NULL,
   detail = "light",
   ees_environment = NULL,
   api_version = NULL,
@@ -63,8 +61,7 @@ get_dataset_versions <- function(
       page_size = page_size,
       page = page,
       verbose = verbose
-    ),
-    httr::add_headers(preview_token = preview_token)
+    )
   ) |>
     httr::content("text") |>
     jsonlite::fromJSON()
@@ -81,8 +78,7 @@ get_dataset_versions <- function(
             page_size = page_size,
             page = page,
             verbose = verbose
-          ),
-          httr::add_headers(preview_token = preview_token)
+          )
         ) |>
           httr::content("text") |>
           jsonlite::fromJSON()

--- a/R/get_dataset_versions.R
+++ b/R/get_dataset_versions.R
@@ -1,6 +1,7 @@
 #' Get data set versions
 #'
 #' @inheritParams api_url
+#' @param preview_token
 #' @param detail Level of detail to return. Given as a character string, it should be one of:
 #' "light" (default) or "full".
 #' Using "light" gives the following:
@@ -32,19 +33,24 @@
 #' @examples
 #' get_dataset_versions(dataset_id = example_id(group = "attendance"))
 get_dataset_versions <- function(
-    dataset_id,
-    detail = "light",
-    ees_environment = NULL,
-    api_version = NULL,
-    page_size = 40,
-    page = NULL,
-    verbose = FALSE) {
+  dataset_id,
+  preview_token = NULL,
+  detail = "light",
+  ees_environment = NULL,
+  api_version = NULL,
+  page_size = 40,
+  page = NULL,
+  verbose = FALSE
+) {
   # Do some basic validation
   validate_page_size(page_size)
 
   detail <- tolower(detail)
   if (!(detail %in% c("light", "full"))) {
-    stop("The detail parameter should be either \"light\" or \"full\". Value passed: ", detail)
+    stop(
+      "The detail parameter should be either \"light\" or \"full\". Value passed: ",
+      detail
+    )
   }
 
   # Make the initial API request
@@ -57,7 +63,8 @@ get_dataset_versions <- function(
       page_size = page_size,
       page = page,
       verbose = verbose
-    )
+    ),
+    httr::add_headers(preview_token = preview_token)
   ) |>
     httr::content("text") |>
     jsonlite::fromJSON()
@@ -74,7 +81,8 @@ get_dataset_versions <- function(
             page_size = page_size,
             page = page,
             verbose = verbose
-          )
+          ),
+          httr::add_headers(preview_token = preview_token)
         ) |>
           httr::content("text") |>
           jsonlite::fromJSON()

--- a/R/get_meta.R
+++ b/R/get_meta.R
@@ -6,7 +6,7 @@
 #' meta endpoint.
 #'
 #' @inheritParams api_url
-#' @inheritParams post_dataset
+#' @inheritParams query_dataset
 #'
 #' @return List of data frames containing a data set's meta data
 #' @export

--- a/R/get_meta.R
+++ b/R/get_meta.R
@@ -6,6 +6,7 @@
 #' meta endpoint.
 #'
 #' @inheritParams api_url
+#' @inheritParams post_dataset
 #'
 #' @return List of data frames containing a data set's meta data
 #' @export
@@ -60,6 +61,7 @@ get_meta <- function(
 #' Get the metadata information for a data set available from the EES API.
 #'
 #' @inheritParams api_url
+#' @inheritParams post_dataset
 #' @param parse Parse result into structured list
 #'
 #' @return Results of query to API meta data endpoint

--- a/R/get_meta.R
+++ b/R/get_meta.R
@@ -13,25 +13,43 @@
 #' @examples
 #' get_meta(example_id())
 get_meta <- function(
-    dataset_id,
-    dataset_version = NULL,
-    ees_environment = NULL,
-    api_version = NULL,
-    verbose = FALSE) {
+  dataset_id,
+  dataset_version = NULL,
+  preview_token = NULL,
+  ees_environment = NULL,
+  api_version = NULL,
+  verbose = FALSE
+) {
   meta_data_response <- get_meta_response(
     dataset_id,
     dataset_version = dataset_version,
+    preview_token = preview_token,
     ees_environment = ees_environment,
     api_version = api_version,
     parse = TRUE,
     verbose = verbose
   )
   meta_data <- list(
-    time_periods = parse_meta_time_periods(meta_data_response$timePeriods, verbose = verbose),
-    locations = parse_meta_location_ids(meta_data_response$locations, verbose = verbose),
-    filter_columns = parse_meta_filter_columns(meta_data_response$filters, verbose = verbose),
-    filter_items = parse_meta_filter_item_ids(meta_data_response$filters, verbose = verbose),
-    indicators = parse_meta_filter_columns(meta_data_response$indicators, verbose = verbose)
+    time_periods = parse_meta_time_periods(
+      meta_data_response$timePeriods,
+      verbose = verbose
+    ),
+    locations = parse_meta_location_ids(
+      meta_data_response$locations,
+      verbose = verbose
+    ),
+    filter_columns = parse_meta_filter_columns(
+      meta_data_response$filters,
+      verbose = verbose
+    ),
+    filter_items = parse_meta_filter_item_ids(
+      meta_data_response$filters,
+      verbose = verbose
+    ),
+    indicators = parse_meta_filter_columns(
+      meta_data_response$indicators,
+      verbose = verbose
+    )
   )
   return(meta_data)
 }
@@ -51,12 +69,14 @@ get_meta <- function(
 #' @examples
 #' eesyapi:::get_meta_response(example_id())
 get_meta_response <- function(
-    dataset_id,
-    dataset_version = NULL,
-    ees_environment = NULL,
-    api_version = NULL,
-    parse = TRUE,
-    verbose = FALSE) {
+  dataset_id,
+  dataset_version = NULL,
+  preview_token = NULL,
+  ees_environment = NULL,
+  api_version = NULL,
+  parse = TRUE,
+  verbose = FALSE
+) {
   # Check that the parse flag is valid
   if (is.logical(parse) == FALSE) {
     stop(
@@ -72,10 +92,14 @@ get_meta_response <- function(
     dataset_id = dataset_id,
     dataset_version = dataset_version,
     ees_environment = ees_environment,
-    api_version = api_version
+    api_version = api_version,
+    verbose = verbose
   )
 
-  response <- httr::GET(meta_url)
+  response <- httr::GET(
+    meta_url,
+    httr::add_headers(`Preview-Token` = preview_token)
+  )
   http_request_error(response)
   if (parse) {
     result <- response |>
@@ -99,13 +123,14 @@ get_meta_response <- function(
 #' @examples
 #' eesyapi:::get_meta_response(example_id())$timePeriods |>
 #'   eesyapi:::parse_meta_time_periods()
-parse_meta_time_periods <- function(api_meta_time_periods,
-                                    verbose = FALSE) {
+parse_meta_time_periods <- function(api_meta_time_periods, verbose = FALSE) {
   if (!("code" %in% names(api_meta_time_periods))) {
     stop("Code column not found in timePeriods data")
   }
   time_periods <- api_meta_time_periods |>
-    dplyr::mutate(code_num = as.numeric(gsub("[a-zA-Z]", "", api_meta_time_periods$code)))
+    dplyr::mutate(
+      code_num = as.numeric(gsub("[a-zA-Z]", "", api_meta_time_periods$code))
+    )
   time_periods <- time_periods |>
     dplyr::arrange(time_periods$code_num) |>
     dplyr::select(-c("code_num"))
@@ -125,8 +150,7 @@ parse_meta_time_periods <- function(api_meta_time_periods,
 #' @examples
 #' eesyapi:::get_meta_response(example_id())$locations |>
 #'   eesyapi:::parse_meta_location_ids()
-parse_meta_location_ids <- function(api_meta_locations,
-                                    verbose = FALSE) {
+parse_meta_location_ids <- function(api_meta_locations, verbose = FALSE) {
   nlevels <- nrow(api_meta_locations$level)
   for (i in 1:nlevels) {
     location_items_i <- api_meta_locations$options |>
@@ -167,8 +191,7 @@ parse_meta_location_ids <- function(api_meta_locations,
 #' @examples
 #' eesyapi:::get_meta_response(example_id())$filters |>
 #'   eesyapi:::parse_meta_filter_columns()
-parse_meta_filter_columns <- function(api_meta_filters,
-                                      verbose = FALSE) {
+parse_meta_filter_columns <- function(api_meta_filters, verbose = FALSE) {
   data.frame(
     col_id = api_meta_filters$id,
     col_name = api_meta_filters$column,
@@ -189,8 +212,9 @@ parse_meta_filter_columns <- function(api_meta_filters,
 #' eesyapi:::get_meta_response(example_id())$filters |>
 #'   eesyapi:::parse_meta_filter_item_ids()
 parse_meta_filter_item_ids <- function(
-    api_meta_filters,
-    verbose = FALSE) {
+  api_meta_filters,
+  verbose = FALSE
+) {
   id <- label <- col_id <- isAggregate <- . <- NULL
   filter_items <- data.frame(
     col_id = api_meta_filters$id,
@@ -201,7 +225,10 @@ parse_meta_filter_item_ids <- function(
       data.table::rbindlist(
         lapply(seq_along(api_meta_filters$options), function(i) {
           data.table::data.table(
-            cbind(api_meta_filters$options[[i]], col_id = api_meta_filters$id[i])
+            cbind(
+              api_meta_filters$options[[i]],
+              col_id = api_meta_filters$id[i]
+            )
           )
         })
       )[, .(item_id = id, item_label = label, col_id)],

--- a/R/parse_api_dataset.R
+++ b/R/parse_api_dataset.R
@@ -12,6 +12,7 @@
 #'
 #' @param api_data_result A json data result list as returned from the API
 #' @inheritParams api_url
+#' @inheritParams post_dataset
 #'
 #' @return Data frame containing API data results
 #'
@@ -58,9 +59,9 @@ parse_api_dataset <- function(
   meta <- get_meta(
     dataset_id,
     dataset_version = dataset_version,
+    preview_token = preview_token,
     ees_environment = ees_environment,
-    api_version = api_version,
-    preview_token = preview_token
+    api_version = api_version
   )
   dplyr::bind_cols(
     api_data_result$timePeriod |>

--- a/R/parse_api_dataset.R
+++ b/R/parse_api_dataset.R
@@ -12,7 +12,7 @@
 #'
 #' @param api_data_result A json data result list as returned from the API
 #' @inheritParams api_url
-#' @inheritParams post_dataset
+#' @inheritParams query_dataset
 #'
 #' @return Data frame containing API data results
 #'

--- a/R/parse_api_dataset.R
+++ b/R/parse_api_dataset.R
@@ -21,12 +21,14 @@
 #' example_data_raw(group = "attendance") |>
 #'   eesyapi:::parse_api_dataset(example_id(group = "attendance"))
 parse_api_dataset <- function(
-    api_data_result,
-    dataset_id,
-    dataset_version = NULL,
-    ees_environment = NULL,
-    api_version = NULL,
-    verbose = FALSE) {
+  api_data_result,
+  dataset_id,
+  dataset_version = NULL,
+  preview_token = NULL,
+  ees_environment = NULL,
+  api_version = NULL,
+  verbose = FALSE
+) {
   if (!is.null(dataset_id)) {
     validate_ees_id(dataset_id, level = "dataset")
   }
@@ -57,7 +59,8 @@ parse_api_dataset <- function(
     dataset_id,
     dataset_version = dataset_version,
     ees_environment = ees_environment,
-    api_version = api_version
+    api_version = api_version,
+    preview_token = preview_token
   )
   dplyr::bind_cols(
     api_data_result$timePeriod |>

--- a/R/parse_sqids.R
+++ b/R/parse_sqids.R
@@ -36,7 +36,9 @@ parse_time_codes <- function(time_periods, verbose = FALSE) {
     time_periods_out <- time_periods_out |>
       dplyr::mutate(
         time_identifier = stringr::str_replace(
-          !!rlang::sym("time_identifier"), "W([0-9]+)", "Week \\1"
+          !!rlang::sym("time_identifier"),
+          "W([0-9]+)",
+          "Week \\1"
         )
       )
   }
@@ -50,7 +52,9 @@ parse_time_codes <- function(time_periods, verbose = FALSE) {
           .default = !!rlang::sym("time_identifier")
         ),
         time_period = stringr::str_replace(
-          !!rlang::sym("time_period"), "([0-9]+)/20([0-9]+)", "\\1/\\2"
+          !!rlang::sym("time_period"),
+          "([0-9]+)/20([0-9]+)",
+          "\\1/\\2"
         )
       )
   }
@@ -125,7 +129,9 @@ parse_geographic_level_codes <- function(geographic_levels, verbose = FALSE) {
 parse_sqids_locations <- function(locations, meta, verbose = FALSE) {
   lookup <- meta |>
     magrittr::use_series("locations") |>
-    dplyr::filter(!!rlang::sym("geographic_level_code") %in% names(locations)) |>
+    dplyr::filter(
+      !!rlang::sym("geographic_level_code") %in% names(locations)
+    ) |>
     dplyr::rename(name = "label")
   for (level in names(locations)) {
     locations <- locations |>
@@ -133,8 +139,13 @@ parse_sqids_locations <- function(locations, meta, verbose = FALSE) {
       dplyr::left_join(
         lookup |>
           dplyr::filter(!!rlang::sym("geographic_level_code") == level) |>
-          dplyr::select(-dplyr::all_of(c("geographic_level_code", "geographic_level"))) |>
-          dplyr::rename_with(~ paste0(tolower(level), "_", .x), !dplyr::matches("item_id")),
+          dplyr::select(
+            -dplyr::all_of(c("geographic_level_code", "geographic_level"))
+          ) |>
+          dplyr::rename_with(
+            ~ paste0(tolower(level), "_", .x),
+            !dplyr::matches("item_id")
+          ),
         by = dplyr::join_by("item_id")
       ) |>
       dplyr::select(-"item_id")
@@ -173,6 +184,13 @@ parse_sqids_filters <- function(filters, meta, verbose = FALSE) {
     magrittr::use_series("filter_columns") |>
     dplyr::filter(!!rlang::sym("col_id") %in% colnames(filters)) |>
     dplyr::pull("col_id")
+  data_filter_ids <- filters |> names()
+  if (any(!(data_filter_ids %in% filter_ids))) {
+    warning(
+      "The following filter IDs were not found in the associated meta data: ",
+      paste(setdiff(data_filter_ids, filter_ids), collapse = ", ")
+    )
+  }
   if (verbose) {
     print(filter_ids)
   }

--- a/R/post_dataset.R
+++ b/R/post_dataset.R
@@ -7,6 +7,7 @@
 #'
 #' @inheritParams api_url
 #' @inheritParams parse_tojson_params
+#' @param preview_token Preview token required for access to private data sets
 #' @param json_query Optional path to a json file containing the query parameters
 #' @param parse Logical flag to activate parsing of the results. Default: TRUE
 #'
@@ -175,9 +176,9 @@ post_dataset <- function(
       parse_api_dataset(
         dataset_id,
         dataset_version,
-        verbose = verbose,
         preview_token = preview_token,
-        ees_environment = ees_environment
+        ees_environment = ees_environment,
+        verbose = verbose
       )
   }
   return(dfresults)

--- a/R/post_dataset.R
+++ b/R/post_dataset.R
@@ -33,20 +33,22 @@
 #' )
 #'
 post_dataset <- function(
-    dataset_id,
-    indicators = NULL,
-    time_periods = NULL,
-    geographies = NULL,
-    filter_items = NULL,
-    json_query = NULL,
-    dataset_version = NULL,
-    ees_environment = NULL,
-    api_version = NULL,
-    page = NULL,
-    page_size = 10000,
-    parse = TRUE,
-    debug = FALSE,
-    verbose = FALSE) {
+  dataset_id,
+  indicators = NULL,
+  time_periods = NULL,
+  geographies = NULL,
+  filter_items = NULL,
+  json_query = NULL,
+  dataset_version = NULL,
+  preview_token = NULL,
+  ees_environment = NULL,
+  api_version = NULL,
+  page = NULL,
+  page_size = 10000,
+  parse = TRUE,
+  debug = FALSE,
+  verbose = FALSE
+) {
   if (is.null(indicators) && is.null(json_query)) {
     stop("At least one of either indicators or json_query must not be NULL.")
   }
@@ -90,12 +92,15 @@ post_dataset <- function(
     dataset_id = dataset_id,
     dataset_version = dataset_version,
     ees_environment = ees_environment,
-    api_version = api_version
-  ) |> httr::POST(
-    body = json_body,
-    encode = "json",
-    httr::content_type("application/json")
-  )
+    api_version = api_version,
+    verbose = verbose
+  ) |>
+    httr::POST(
+      body = json_body,
+      encode = "json",
+      httr::content_type("application/json"),
+      httr::add_headers(`Preview-Token` = preview_token)
+    )
   if (verbose) {
     print(response)
     print(
@@ -122,7 +127,9 @@ post_dataset <- function(
       if (response_json$paging$totalPages * page_size > 100000) {
         message(
           paste(
-            "Downloading up to", response_json$paging$totalPages * page_size, "rows.",
+            "Downloading up to",
+            response_json$paging$totalPages * page_size,
+            "rows.",
             "This may take a while.",
             "We recommend downloading the full data set using preview_dataset()",
             "for large volumes of data."
@@ -149,7 +156,8 @@ post_dataset <- function(
           httr::POST(
             body = json_body,
             encode = "json",
-            httr::content_type("application/json")
+            httr::content_type("application/json"),
+            httr::add_headers(`Preview-Token` = preview_token)
           ) |>
           httr::content("text") |>
           jsonlite::fromJSON()
@@ -166,7 +174,9 @@ post_dataset <- function(
     dfresults <- dfresults |>
       parse_api_dataset(
         dataset_id,
+        dataset_version,
         verbose = verbose,
+        preview_token = preview_token,
         ees_environment = ees_environment
       )
   }

--- a/R/post_dataset.R
+++ b/R/post_dataset.R
@@ -7,9 +7,7 @@
 #'
 #' @inheritParams api_url
 #' @inheritParams parse_tojson_params
-#' @param preview_token Preview token required for access to private data sets
-#' @param json_query Optional path to a json file containing the query parameters
-#' @param parse Logical flag to activate parsing of the results. Default: TRUE
+#' @inheritParams query_dataset
 #'
 #' @return Data frame containing query results of an API data set
 #'

--- a/R/preview_dataset.R
+++ b/R/preview_dataset.R
@@ -43,12 +43,14 @@
 #' # Get all rows
 #' preview_dataset(example_id("dataset"), n_max = Inf)
 preview_dataset <- function(
-    dataset_id,
-    dataset_version = NULL,
-    api_version = NULL,
-    ees_environment = default_ees_environment(),
-    n_max = 10,
-    verbose = FALSE) {
+  dataset_id,
+  dataset_version = NULL,
+  preview_token = NULL,
+  api_version = NULL,
+  ees_environment = default_ees_environment(),
+  n_max = 10,
+  verbose = FALSE
+) {
   # Validation ----------------------------------------------------------------
   if (!is.null(dataset_version)) {
     warning(
@@ -86,6 +88,7 @@ preview_dataset <- function(
 
   response <- query_url |>
     httr2::request() |>
+    httr2::req_headers(preview_token = preview_token) |>
     httr2::req_perform()
 
   http_request_error(response, verbose = verbose)

--- a/R/preview_dataset.R
+++ b/R/preview_dataset.R
@@ -45,7 +45,6 @@
 preview_dataset <- function(
   dataset_id,
   dataset_version = NULL,
-  preview_token = NULL,
   api_version = NULL,
   ees_environment = default_ees_environment(),
   n_max = 10,
@@ -88,7 +87,6 @@ preview_dataset <- function(
 
   response <- query_url |>
     httr2::request() |>
-    httr2::req_headers(preview_token = preview_token) |>
     httr2::req_perform()
 
   http_request_error(response, verbose = verbose)

--- a/R/query_dataset.R
+++ b/R/query_dataset.R
@@ -105,7 +105,9 @@
 #'  and so on).
 #'
 #' @inheritParams api_url
-#' @inheritParams post_dataset
+#' @param preview_token Preview token required for access to private data sets
+#' @param json_query Optional path to a json file containing the query parameters
+#' @param parse Logical flag to activate parsing of the results. Default: TRUE
 #' @param method The API query method to be used. Can be  "POST" or "GET". Default: "POST".
 #'
 #' @return Data frame containing query results

--- a/R/query_dataset.R
+++ b/R/query_dataset.R
@@ -105,6 +105,7 @@
 #'  and so on).
 #'
 #' @inheritParams api_url
+#' @inheritParams parse_tojson_params
 #' @param preview_token Preview token required for access to private data sets
 #' @param json_query Optional path to a json file containing the query parameters
 #' @param parse Logical flag to activate parsing of the results. Default: TRUE
@@ -186,6 +187,7 @@ query_dataset <- function(
   ees_environment = NULL,
   api_version = NULL,
   page_size = 10000,
+  parse = TRUE,
   page = NULL,
   debug = FALSE,
   verbose = FALSE
@@ -227,6 +229,7 @@ query_dataset <- function(
       api_version = api_version,
       page_size = page_size,
       page = page,
+      parse = parse,
       debug = debug,
       verbose = verbose
     )
@@ -293,6 +296,7 @@ query_dataset <- function(
       api_version = api_version,
       page_size = page_size,
       page = page,
+      parse = parse,
       verbose = verbose
     )
   }

--- a/R/query_dataset.R
+++ b/R/query_dataset.R
@@ -172,20 +172,22 @@
 #' )
 #'
 query_dataset <- function(
-    dataset_id,
-    indicators = NULL,
-    time_periods = NULL,
-    geographies = NULL,
-    filter_items = NULL,
-    json_query = NULL,
-    method = "POST",
-    dataset_version = NULL,
-    ees_environment = NULL,
-    api_version = NULL,
-    page_size = 10000,
-    page = NULL,
-    debug = FALSE,
-    verbose = FALSE) {
+  dataset_id,
+  indicators = NULL,
+  time_periods = NULL,
+  geographies = NULL,
+  filter_items = NULL,
+  json_query = NULL,
+  method = "POST",
+  dataset_version = NULL,
+  preview_token = NULL,
+  ees_environment = NULL,
+  api_version = NULL,
+  page_size = 10000,
+  page = NULL,
+  debug = FALSE,
+  verbose = FALSE
+) {
   if (!(method %in% c("POST", "GET"))) {
     stop(
       paste(
@@ -195,10 +197,13 @@ query_dataset <- function(
     )
   }
   if (is.null(indicators) && (is.null(json_query) || method == "GET")) {
-    warning("No indicators provided, defaulted to using all indicators from meta data")
+    warning(
+      "No indicators provided, defaulted to using all indicators from meta data"
+    )
     indicators <- get_meta(
       dataset_id,
       dataset_version = dataset_version,
+      preview_token = preview_token,
       ees_environment = ees_environment,
       api_version = api_version,
       verbose = verbose
@@ -215,6 +220,7 @@ query_dataset <- function(
       filter_items = filter_items,
       json_query = json_query,
       dataset_version = dataset_version,
+      preview_token = preview_token,
       ees_environment = ees_environment,
       api_version = api_version,
       page_size = page_size,
@@ -280,6 +286,7 @@ query_dataset <- function(
       locations = locations,
       filter_items = filter_items,
       dataset_version = dataset_version,
+      preview_token = preview_token,
       ees_environment = ees_environment,
       api_version = api_version,
       page_size = page_size,

--- a/man/get_dataset.Rd
+++ b/man/get_dataset.Rd
@@ -12,6 +12,7 @@ get_dataset(
   locations = NULL,
   filter_items = NULL,
   dataset_version = NULL,
+  preview_token = NULL,
   ees_environment = NULL,
   api_version = NULL,
   page = NULL,

--- a/man/get_dataset.Rd
+++ b/man/get_dataset.Rd
@@ -37,6 +37,8 @@ of "get-dataset-versions", "get-summary", "get-meta", "get-csv", "get-data" or "
 
 \item{dataset_version}{Version of data set to be connected to}
 
+\item{preview_token}{Preview token required for access to private data sets}
+
 \item{ees_environment}{EES ees_environment to connect to: "dev", "test", "preprod" or "prod"}
 
 \item{api_version}{EES API version}

--- a/man/get_meta.Rd
+++ b/man/get_meta.Rd
@@ -7,6 +7,7 @@
 get_meta(
   dataset_id,
   dataset_version = NULL,
+  preview_token = NULL,
   ees_environment = NULL,
   api_version = NULL,
   verbose = FALSE
@@ -17,6 +18,8 @@ get_meta(
 of "get-dataset-versions", "get-summary", "get-meta", "get-csv", "get-data" or "post-data"}
 
 \item{dataset_version}{Version of data set to be connected to}
+
+\item{preview_token}{Preview token required for access to private data sets}
 
 \item{ees_environment}{EES ees_environment to connect to: "dev", "test", "preprod" or "prod"}
 

--- a/man/get_meta_response.Rd
+++ b/man/get_meta_response.Rd
@@ -7,6 +7,7 @@
 get_meta_response(
   dataset_id,
   dataset_version = NULL,
+  preview_token = NULL,
   ees_environment = NULL,
   api_version = NULL,
   parse = TRUE,
@@ -18,6 +19,8 @@ get_meta_response(
 of "get-dataset-versions", "get-summary", "get-meta", "get-csv", "get-data" or "post-data"}
 
 \item{dataset_version}{Version of data set to be connected to}
+
+\item{preview_token}{Preview token required for access to private data sets}
 
 \item{ees_environment}{EES ees_environment to connect to: "dev", "test", "preprod" or "prod"}
 

--- a/man/parse_api_dataset.Rd
+++ b/man/parse_api_dataset.Rd
@@ -8,6 +8,7 @@ parse_api_dataset(
   api_data_result,
   dataset_id,
   dataset_version = NULL,
+  preview_token = NULL,
   ees_environment = NULL,
   api_version = NULL,
   verbose = FALSE
@@ -20,6 +21,8 @@ parse_api_dataset(
 of "get-dataset-versions", "get-summary", "get-meta", "get-csv", "get-data" or "post-data"}
 
 \item{dataset_version}{Version of data set to be connected to}
+
+\item{preview_token}{Preview token required for access to private data sets}
 
 \item{ees_environment}{EES ees_environment to connect to: "dev", "test", "preprod" or "prod"}
 

--- a/man/post_dataset.Rd
+++ b/man/post_dataset.Rd
@@ -12,6 +12,7 @@ post_dataset(
   filter_items = NULL,
   json_query = NULL,
   dataset_version = NULL,
+  preview_token = NULL,
   ees_environment = NULL,
   api_version = NULL,
   page = NULL,
@@ -37,6 +38,8 @@ locations to be queried.}
 \item{json_query}{Optional path to a json file containing the query parameters}
 
 \item{dataset_version}{Version of data set to be connected to}
+
+\item{preview_token}{Preview token required for access to private data sets}
 
 \item{ees_environment}{EES ees_environment to connect to: "dev", "test", "preprod" or "prod"}
 

--- a/man/query_dataset.Rd
+++ b/man/query_dataset.Rd
@@ -17,6 +17,7 @@ query_dataset(
   ees_environment = NULL,
   api_version = NULL,
   page_size = 10000,
+  parse = TRUE,
   page = NULL,
   debug = FALSE,
   verbose = FALSE
@@ -29,6 +30,9 @@ of "get-dataset-versions", "get-summary", "get-meta", "get-csv", "get-data" or "
 \item{indicators}{Indicators required as a string or vector of strings (required)}
 
 \item{time_periods}{Time periods required as a string ("period|code") or vector of strings}
+
+\item{geographies}{String, vector or data frame containing the geographic levels and
+locations to be queried.}
 
 \item{filter_items}{Filter items required as a string or vector of strings}
 
@@ -46,11 +50,13 @@ of "get-dataset-versions", "get-summary", "get-meta", "get-csv", "get-data" or "
 
 \item{page_size}{Number of results to return in a single query}
 
+\item{parse}{Logical flag to activate parsing of the results. Default: TRUE}
+
 \item{page}{Page number of query results to return}
 
-\item{verbose}{Run with additional contextual messaging. Logical, default = FALSE}
+\item{debug}{Run POST query in debug mode. Logical, default = FALSE}
 
-\item{parse}{Logical flag to activate parsing of the results. Default: TRUE}
+\item{verbose}{Run with additional contextual messaging. Logical, default = FALSE}
 }
 \value{
 Data frame containing query results

--- a/man/query_dataset.Rd
+++ b/man/query_dataset.Rd
@@ -30,9 +30,6 @@ of "get-dataset-versions", "get-summary", "get-meta", "get-csv", "get-data" or "
 
 \item{time_periods}{Time periods required as a string ("period|code") or vector of strings}
 
-\item{geographies}{String, vector or data frame containing the geographic levels and
-locations to be queried.}
-
 \item{filter_items}{Filter items required as a string or vector of strings}
 
 \item{json_query}{Optional path to a json file containing the query parameters}
@@ -51,9 +48,9 @@ locations to be queried.}
 
 \item{page}{Page number of query results to return}
 
-\item{debug}{Run POST query in debug mode. Logical, default = FALSE}
-
 \item{verbose}{Run with additional contextual messaging. Logical, default = FALSE}
+
+\item{parse}{Logical flag to activate parsing of the results. Default: TRUE}
 }
 \value{
 Data frame containing query results

--- a/man/query_dataset.Rd
+++ b/man/query_dataset.Rd
@@ -13,6 +13,7 @@ query_dataset(
   json_query = NULL,
   method = "POST",
   dataset_version = NULL,
+  preview_token = NULL,
   ees_environment = NULL,
   api_version = NULL,
   page_size = 10000,
@@ -39,6 +40,8 @@ locations to be queried.}
 \item{method}{The API query method to be used. Can be  "POST" or "GET". Default: "POST".}
 
 \item{dataset_version}{Version of data set to be connected to}
+
+\item{preview_token}{Preview token required for access to private data sets}
 
 \item{ees_environment}{EES ees_environment to connect to: "dev", "test", "preprod" or "prod"}
 


### PR DESCRIPTION
# Brief overview of changes

Adding in functionality to use preview_tokens to access pre-release data.

I've added this to:
- get_meta
- query_dataset
- post_dataset
- get_dataset
- some of the related parsing functions that can reference the meta data independently

I also experimented with the following endpoints, but found that they don't have the ability to use the preview tokens:
- data set versions table
- data set csv endpoint

## Why are these changes being made?

We want to be able to use eesyapi to access pre-release data

## Additional information for reviewers

I've not written any specific extra tests given that preview tokens are time limited, so would need recreating too regularly.

Also, I did these updates whilst I had Air turned on, so any files I've saved have been Aired.

## Issue ticket number/s and link

Closes #30 