### PR TITLE
Fix get_dataset_version() rownames error

### DIFF
--- a/R/examples.R
+++ b/R/examples.R
@@ -18,7 +18,7 @@
 #' @param ees_environment Environment to return a working example for: "dev", "test" or "prod"
 #' @param group Choose the publication group of examples to use. Options are:
 #'   - "attendance": Large example data set, careful what you ask for
-#'   - "public-api-testing": Smaller example data set
+#'   - "absence": Smaller example data set
 #'
 #' @return String, vector or list containing example ID(s) present in the API
 #' @export

--- a/R/get_dataset_versions.R
+++ b/R/get_dataset_versions.R
@@ -82,8 +82,9 @@ get_dataset_versions <- function(
         ) |>
           httr::content("text") |>
           jsonlite::fromJSON()
-        response$results <- response$results |>
-          rbind(response_page$results)
+        response$results <- dplyr::bind_rows(
+          response$results, response_page$results
+        )
       }
     }
   }

--- a/man/example_data_raw.Rd
+++ b/man/example_data_raw.Rd
@@ -10,7 +10,7 @@ example_data_raw(group = "attendance", size = 32)
 \item{group}{Choose the publication group of examples to use. Options are:
 \itemize{
 \item "attendance": Large example data set, careful what you ask for
-\item "public-api-testing": Smaller example data set
+\item "absence": Smaller example data set
 }}
 
 \item{size}{Number of rows to return (max = 1000)}

--- a/man/example_id.Rd
+++ b/man/example_id.Rd
@@ -27,7 +27,7 @@ example short / long filter query list.
 \item{group}{Choose the publication group of examples to use. Options are:
 \itemize{
 \item "attendance": Large example data set, careful what you ask for
-\item "public-api-testing": Smaller example data set
+\item "absence": Smaller example data set
 }}
 }
 \value{


### PR DESCRIPTION
# Brief overview of changes

Swaps base R `rbind()` for dplyr's `bind_rows()` to prevent an error with duplicate row names.

## Why are these changes being made?

The regular test runs starting failing around 3 weeks ago for no apparent reason, we hadn't made any updates and I did a quick check of R / package versions and can't see any major releases in that time.

Example here - https://github.com/dfe-analytical-services/eesyapi.R/actions/runs/16515259389

<img width="843" height="426" alt="image" src="https://github.com/user-attachments/assets/e3ead901-bc2a-4617-b5d1-d46ea9e1ff3e" />

<img width="1837" height="857" alt="image" src="https://github.com/user-attachments/assets/83ff6033-9e61-4468-b7d9-a3c0b4181333" />

## Detailed description of changes

1. Updated the `get_dataset_version()` function, no meaningful changes to behaviour, just doing the same thing in a different way to prevent the error that appeared.

2. Fixed a typo in the `example_id()` docs that tripped me up when trying to test out the error.

## Additional information for reviewers

The `get_dataset_version()` example was failing with an error about duplicate rownames. This code was working, and then started failing out of nowhere, for a reason I haven't got to the bottom of. I tried faffing around to pin down what was happening, and to manually set rownames, then got annoyed with it and eventually caved to use the dplyr `bind_rows()`, which seems to be more robust.

Probably not a lot to test here as there's no changes to the package. Check for anything rogue in the file changes and make sure the tests all pass for you as well.

## Issue ticket number/s and link

Failed actions runs: https://github.com/dfe-analytical-services/eesyapi.R/actions/runs/16515259389/job/46704798055
