### PR TITLE
Add .lintr to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^pkgdown$
 ^\.github$
 ^data-raw$
+^\.lintr$


### PR DESCRIPTION
<!-- 
Hey, thanks for raising a PR! We're excited to see what you've done!
To help us review the changes, please complete each section in this template by replacing '...' with details to help the reviewers of this pull request. 
-->

# Brief overview of changes

Add .lintr file to .Rbuildignore

## Why are these changes being made?

.lintr is a development file and should be excluded from package bundle. Addresses check() note.

## Detailed description of changes

Add .lintr file to .Rbuildignore

## Additional information for reviewers

Does not address 'argument items with no description' note.

## Issue ticket number/s and link

#18 
