### PR TITLE
New feature/dataset versions preview

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eesyapi
 Title: EES-y API
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: c(
     person("Rich", "Bielby", , "richard.bielby@education.gov.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9070-9969")),

--- a/R/api_url.R
+++ b/R/api_url.R
@@ -177,7 +177,12 @@ api_url <- function(
     if (endpoint == "get-dataset-versions") {
       url <- paste0(
         url,
-        "/versions"
+        "/versions",
+                ifelse(
+            !is.null(page) & !is.null(page_size),
+            paste0("?", api_url_pages(page_size = page_size, page = page)),
+            ""
+          )
       )
     } else if (endpoint != "get-summary") {
       url <- paste0(

--- a/R/api_url.R
+++ b/R/api_url.R
@@ -175,14 +175,18 @@ api_url <- function(
       )
     )
     if (endpoint == "get-dataset-versions") {
+      # Force first page if page size is given by user and page isn't
+      if (!is.null(page_size) && is.null(page)) {
+        page <- 1
+      }
       url <- paste0(
         url,
         "/versions",
-                ifelse(
-            !is.null(page) & !is.null(page_size),
-            paste0("?", api_url_pages(page_size = page_size, page = page)),
-            ""
-          )
+        ifelse(
+          !is.null(page_size),
+          paste0("?", api_url_pages(page_size = page_size, page = page)),
+          ""
+        )
       )
     } else if (endpoint != "get-summary") {
       url <- paste0(

--- a/R/get_dataset_versions.R
+++ b/R/get_dataset_versions.R
@@ -1,6 +1,7 @@
 #' Get data set versions
 #'
 #' @inheritParams api_url
+#' @inheritParams query_dataset
 #' @param detail Level of detail to return. Given as a character string, it should be one of:
 #' "light" (default) or "full".
 #' Using "light" gives the following:
@@ -34,14 +35,22 @@
 get_dataset_versions <- function(
   dataset_id,
   detail = "light",
+  preview_token = NULL,
   ees_environment = NULL,
   api_version = NULL,
-  page_size = 40,
+  page_size = 20,
   page = NULL,
   verbose = FALSE
 ) {
   # Do some basic validation
   validate_page_size(page_size)
+  if (page_size > 20) {
+    warning(
+      "The API only allows page_sizes of less than 20 for the dataset versions endpoint.",
+      "Forcing user set page_size to 20."
+    )
+    page_size <- 20
+  }
 
   detail <- tolower(detail)
   if (!(detail %in% c("light", "full"))) {
@@ -61,7 +70,8 @@ get_dataset_versions <- function(
       page_size = page_size,
       page = page,
       verbose = verbose
-    )
+    ),
+    httr::add_headers(`Preview-Token` = preview_token)
   ) |>
     httr::content("text") |>
     jsonlite::fromJSON()
@@ -78,12 +88,14 @@ get_dataset_versions <- function(
             page_size = page_size,
             page = page,
             verbose = verbose
-          )
+          ),
+          httr::add_headers(`Preview-Token` = preview_token)
         ) |>
           httr::content("text") |>
           jsonlite::fromJSON()
         response$results <- dplyr::bind_rows(
-          response$results, response_page$results
+          response$results,
+          response_page$results
         )
       }
     }

--- a/man/get_dataset_versions.Rd
+++ b/man/get_dataset_versions.Rd
@@ -7,9 +7,10 @@
 get_dataset_versions(
   dataset_id,
   detail = "light",
+  preview_token = NULL,
   ees_environment = NULL,
   api_version = NULL,
-  page_size = 40,
+  page_size = 20,
   page = NULL,
   verbose = FALSE
 )
@@ -40,6 +41,8 @@ Using "full" adds the following in addition to the above:
 \item indicators - names of indicators in the data set version
 \item notes - any additional information
 }}
+
+\item{preview_token}{Preview token required for access to private data sets}
 
 \item{ees_environment}{EES ees_environment to connect to: "dev", "test", "preprod" or "prod"}
 


### PR DESCRIPTION
# Brief overview of changes

The dataset versions endpoint on EES had an update a while back to allow it to be queried with a preview token to see any unpublished versions that are queued up. This PR updates the `eesyapi::get_dataset_versions()` script updated to match up with that new functionality.

Also spotted a bug in the same function whereby it wasn't handling pages and page_size correctly, so I've put some fixes in around that whilst making updates,

